### PR TITLE
FIX: Generate queries without initial '/' in the path

### DIFF
--- a/addr2line.go
+++ b/addr2line.go
@@ -97,6 +97,7 @@ func workload(a *addr2line.Addr2line, ch chan workloads, insert_func ins_f) {
 
 	for {
 		e = <-ch
+
 		switch e.Name {
 		case "None":
 			insert_func(e.DB, e.Query, false)
@@ -125,5 +126,6 @@ func spawn_query(db *sql.DB, addr uint64, name string, context *Context, query s
 
 // Get filename and line given an offset (addr)
 func GetFileReference(context *Context, addr uint64) ([]addr2line.Result, error) {
-	return context.instance.Resolve(addr)
+	res, err := context.instance.Resolve(addr)
+	return res, err
 }

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func main() {
 
 			// query for addr2line file prefix
 			if a.Name == "sym.start_kernel" {
-				var start_kernel_file_tail string = "/init/main.c"
+				var start_kernel_file_tail string = "init/main.c"
 				results, err := GetFileReference(context, a.Offset)
 				if err != nil {
 					panic(err)
@@ -148,7 +148,9 @@ func main() {
 				if len(results) > 0 {
 					r := results[0]
 					start_kernel_file := filepath.Clean(r.File)
-					addr2line_prefix = start_kernel_file[:len(start_kernel_file)-len(start_kernel_file_tail)]
+					if len(start_kernel_file) > len(start_kernel_file_tail) {
+						addr2line_prefix = start_kernel_file[:len(start_kernel_file)-len(start_kernel_file_tail)]
+					}
 				} else {
 					fmt.Printf("\nWARNING: cannot get addr2line prefix tags results may be affected!\n")
 				}

--- a/maintainers.go
+++ b/maintainers.go
@@ -206,10 +206,10 @@ func generate_queries(maintainers_fn string, items []m_item, template_query stri
 			for _, f := range files {
 				if isdir(f) {
 					for _, x := range navigate(f) {
-						res = append(res, fmt.Sprintf(template_query, strings.ReplaceAll(item.subsystem_name, "'", "`"), filepath.Clean(x)[basepath_len:], id))
+						res = append(res, fmt.Sprintf(template_query, strings.ReplaceAll(item.subsystem_name, "'", "`"), filepath.Clean(x)[basepath_len+1:], id))
 					}
 				} else {
-					res = append(res, fmt.Sprintf(template_query, strings.ReplaceAll(item.subsystem_name, "'", "`"), filepath.Clean(f)[basepath_len:], id))
+					res = append(res, fmt.Sprintf(template_query, strings.ReplaceAll(item.subsystem_name, "'", "`"), filepath.Clean(f)[basepath_len+1:], id))
 				}
 			}
 		}


### PR DESCRIPTION
This patch fixes path management for in-tree/out-tree builds