### PR TITLE
Add index to keep query "insert into xrefs (caller, ..." fast

### DIFF
--- a/db.txt
+++ b/db.txt
@@ -14,3 +14,4 @@ create index on xrefs   using hash (callee);
 create index on files   using hash (file_name);
 create index on tags    using hash (tag_file_ref_id);
 create index on symbols using hash (symbol_file_ref_id);
+create index on symbols using btree (symbol_address COLLATE "default" ASC NULLS LAST, symbol_instance_id_ref ASC NULLS LAST);


### PR DESCRIPTION
The DB access to perform the "insert into xrefs .." relies on 2 subqueries like:

SELECT symbol_id from symbols where symbol_address ='0xffffffff812cf690' and symbol_instance_id_ref=XY

This index is useful to optimize them.